### PR TITLE
Align more button correctly when weekend is hidden

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -212,6 +212,7 @@ class DateContentRow extends React.Component {
           {!!extra.length && (
             <EventEndingRow
               {...props}
+              slots={range.length}
               start={first}
               end={last}
               segments={extra}


### PR DESCRIPTION
Before:
![image](https://github.com/DaPulse/react-big-calendar/assets/135718140/7db8a5d5-3704-4e03-948a-3cdba5e67756)

"more" button is not in the right place if hide_weekends = true

After:
![image](https://github.com/DaPulse/react-big-calendar/assets/135718140/fa3f8599-4bac-4e65-9a53-80e79278e494)
